### PR TITLE
[MRG] Change the `-o` help message in `mass-merge.py`

### DIFF
--- a/mass-merge.py
+++ b/mass-merge.py
@@ -179,7 +179,7 @@ def main():
     )
     p.add_argument(
         '-o', '--output', metavar='FILE', default='-',
-        help='output signature to this file (default stdout)'
+        help='output merged database to this file (default stdout)'
     )
     p.add_argument(
         '--flatten', action='store_true',


### PR DESCRIPTION
I was pretty confused by the help message for `-o` when using `mass-merge.py`. I didn't know if each set of merged signatures would be output to a new file or if they would all be put in a new zip file. 

The top of the help message looks like:
```
usage: mass-merge.py [-h] [-q] [-d] --merge-col MERGE_COL [-o FILE] [--flatten] [-f] [--check] -F FROM_SPREADSHEET [-k K] [--protein] [--no-protein] [--dayhoff]
                     [--no-dayhoff] [--hp] [--no-hp] [--dna] [--no-dna]
                     dblist [dblist ...]
```

So I would have expected `-o` to correspond with a new output database

Instead, the help message stated
```
-o FILE, --output FILE
                        output signature to this file (default stdout)
```

I suggested a change, but i'm not sure it's the best wording. I could go with `output merged signatures to this zip file` or something instead as well. 